### PR TITLE
support for linux client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/client.py
+++ b/client.py
@@ -1,22 +1,33 @@
 import time
 import threading
 import os
+import platform
 from input_thread import InputThread, read_queue, send_queue,read,stop_threads
 from chat_client import chat_client
-import winsound
-import win32gui
 
 
-this_window=win32gui.GetForegroundWindow()
+os_type = platform.system()
+
+if os_type == 'Linux':
+    clearscreen_command = 'clear'
+elif os_type == 'windows':
+    import winsound
+    import win32gui
+    clearscreen_command = 'cls'
+    this_window=win32gui.GetForegroundWindow()
 
 def play_sound(filename):
-
+    if not os_type == 'windows':
+        return False
+    
     filepath=os.path.join(BASE_DIR,filename)
     os.system('powershell -c (New-Object Media.SoundPlayer '+filepath+').PlaySync();')
 
 
 
 def is_window_focused(this_window):
+    if not os_type == 'windows':
+        return False
     f = win32gui.GetForegroundWindow()
     if f == this_window:
         return True
@@ -24,7 +35,7 @@ def is_window_focused(this_window):
         return False
 
 
-os.system('cls')
+os.system(str(clearscreen_command))
 
 BASE_DIR = (os.path.dirname(os.path.abspath(__file__)))
 
@@ -81,12 +92,13 @@ while run==True:
         message=read_queue.get()
         print('\x1b[2K\r' + message, end='\n')
         print('\r<'+user+'>: ' + new_output, end='')
-        if is_window_focused(this_window):
-            notified=False
-            # play_sound('DragonBallImpact.wav')
-        elif notified==False:
-            play_sound('DonorCardAppears.wav')
-            notified=True
+        if os_type == 'windows':
+            if is_window_focused(this_window):
+                notified=False
+                # play_sound('DragonBallImpact.wav')
+            elif notified==False:
+                play_sound('DonorCardAppears.wav')
+                notified=True
     # else:
     #     try:
     #         data=s.recv(1024)

--- a/input_thread.py
+++ b/input_thread.py
@@ -1,10 +1,17 @@
 import threading
 from queue import Queue
 import time
-import msvcrt
+import platform
+if platform.system() == 'Linux':
+    import getch as ugetch
+    LINE_ENDING = '\n'
+elif platform.system() == 'windows':
+    import msvcrt as ugetch
+    LINE_ENDING = '\r'    
 
-getch=msvcrt.getch
-getwch=msvcrt.getwch
+os_type = platform.system()
+getch=ugetch.getch
+#getwch=ugetch.getwch
 
 send_queue=Queue()
 read_queue_buffer=Queue()
@@ -38,7 +45,8 @@ class InputThread(threading.Thread):
             # checks for arrow keys - need to call getch twice otherwise --- crush
             if letter==b'\xe0':
                 letter=getch()
-                letter=letter.decode()
+                if os_type == 'windows':
+                    letter=letter.decode()
 
                 # placeholders for arrow keys functionality
                 if letter=='K':
@@ -56,8 +64,9 @@ class InputThread(threading.Thread):
 
                 letter=''
             else:
-                letter=letter.decode("utf-8", "ignore")
-            if letter == '\r':
+                if os_type == 'windows':
+                    letter=letter.decode("utf-8", "ignore")
+            if letter == LINE_ENDING:
                 if len(self.sentence)>0:
                     temp=''.join(self.sentence)
                     send_queue.put(temp)


### PR DESCRIPTION
By querying the type of platform for 'Linux' or 'Windows' it is possible to import the right library for each platform, get correct line endings and shell commands like clear screen ('cls' / 'clear').
Some features like audio alerts that use Windows libraries and PowerShell calls are ignored on non-windows platforms.

I also added .gitignore from https://github.com/github/gitignore/blob/master/Python.gitignore
